### PR TITLE
Check React Hooks is present

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ You can read more about the library [>> HERE <<](http://bit.ly/wdyr1).
 Common fixing scenarios this library can help to eliminate can be found [>> HERE <<](http://bit.ly/wdyr02).
 
 ## Part 3 - Hooks
+
+Hooks wasn't available in React versions below the `16.8.0` version. This feature started to be developed in earliers versions.
+However, to avoid instabilities and issues with unnoficial release of Hooks. The minimum version to use this feature is `>= 16.8.0`.
+If you pass `trackHooks: true`(**default**) in the options, it will check your React version too.
+
 Understand and fix hook issues [>> HERE <<](http://bit.ly/wdyr3).
 
 ## Sandbox

--- a/src/whyDidYouRender.js
+++ b/src/whyDidYouRender.js
@@ -224,8 +224,9 @@ export default function whyDidYouRender(React, userOptions){
   Object.assign(React.createFactory, origCreateFactory)
 
   let origHooks
-
-  if(options.trackHooks){
+	const hasHooksVersion = parseInt(React.version.split('.').slice(0, 2).join('')) >= 168
+	
+  if(hasHooksVersion && React.useState && options.trackHooks){
     const patchedHooks = mapValues(hooksConfig, (hookConfig, hookName) => {
       return (...args) => {
         const origHook = origHooks[hookName]


### PR DESCRIPTION
# Problem

Using a quite recent version of React, per example: `16.4.*` by default you can't use the hooks feature.
The default setting is to `trackHooks: true`. It can cause trouble if people don't read the documentation completely.

# Solution
* Add version check: `=> 16.8.0` official release. The`16.7.0` already has some files and may have the `useState` method.
* Check if `useState`exists. This is one of the basic and pre-requisites methods for Hooks works.
* Add more description on documentation.