### PR TITLE
Adds TypeScript definition for `FunctionComponent.whyDidYouRender` prop

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -40,3 +40,9 @@ declare module '@welldone-software/why-did-you-render' {
 
   export default function whyDidYouRender(react: typeof React, options?: WhyDidYouRenderOptions): typeof React;
 }
+
+declare namespace React {
+  interface FunctionComponent<P = {}> {
+    whyDidYouRender?: boolean;
+  }
+}


### PR DESCRIPTION
Allows the following to be valid TypeScript:
```typescript
const MyFunctionalComponent: React.FC = () => { ... };
MyFunctionalComponent.whyDidYouRender = true;
```
Technically the namespace augmentation should be something like this:
```typescript
  interface FunctionComponent<P = {}> {
    whyDidYouRender?: boolean|WhyDidYouRenderOptions; 👈👈👈
  }
```
but there are issues referencing the `WhyDidYouRenderOptions` interface from outside the module. This is at least a step in the right direction.