### PR TITLE
Updated types to include defaultNotifier

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -50,8 +50,6 @@ declare namespace WhyDidYouRender {
   type WhyDidYouRenderComponentMember = WhyDidYouRenderOptions|boolean
   
   type Notifier = (options: UpdateInfo) => void
-
-  interface IWhyDidYouRender { (react: typeof React, options?: WhyDidYouRenderOptions): typeof React; defaultNotifier: Notifier; }
 }
 
 declare module '@welldone-software/why-did-you-render' {
@@ -59,9 +57,15 @@ declare module '@welldone-software/why-did-you-render' {
   export import UpdateInfo = WhyDidYouRender.UpdateInfo;
   export import WhyDidYouRenderOptions = WhyDidYouRender.WhyDidYouRenderOptions;
   export import HookDifference = WhyDidYouRender.HookDifference;
-  import IWhyDidYouRender = WhyDidYouRender.IWhyDidYouRender;
+  export import Notifier = WhyDidYouRender.Notifier;
 
-  export default IWhyDidYouRender;
+  function whyDidYouRender(react: typeof React, options?: WhyDidYouRenderOptions): typeof React;
+
+  namespace whyDidYouRender {
+    export const defaultNotifier: Notifier;
+  }
+
+  export default whyDidYouRender;
 }
 
 declare namespace React {

--- a/types.d.ts
+++ b/types.d.ts
@@ -44,10 +44,14 @@ declare namespace WhyDidYouRender {
     titleColor?: string;
     diffNameColor?: string;
     diffPathColor?: string;
-    notifier?: (options: UpdateInfo) => void;
+    notifier?: Notifier;
   }
 
   type WhyDidYouRenderComponentMember = WhyDidYouRenderOptions|boolean
+  
+  type Notifier = (options: UpdateInfo) => void
+
+  interface IWhyDidYouRender { (react: typeof React, options?: WhyDidYouRenderOptions): typeof React; defaultNotifier: Notifier; }
 }
 
 declare module '@welldone-software/why-did-you-render' {
@@ -55,8 +59,9 @@ declare module '@welldone-software/why-did-you-render' {
   export import UpdateInfo = WhyDidYouRender.UpdateInfo;
   export import WhyDidYouRenderOptions = WhyDidYouRender.WhyDidYouRenderOptions;
   export import HookDifference = WhyDidYouRender.HookDifference;
+  import IWhyDidYouRender = WhyDidYouRender.IWhyDidYouRender;
 
-  export default function whyDidYouRender(react: typeof React, options?: WhyDidYouRenderOptions): typeof React;
+  export default IWhyDidYouRender
 }
 
 declare namespace React {

--- a/types.d.ts
+++ b/types.d.ts
@@ -61,7 +61,7 @@ declare module '@welldone-software/why-did-you-render' {
   export import HookDifference = WhyDidYouRender.HookDifference;
   import IWhyDidYouRender = WhyDidYouRender.IWhyDidYouRender;
 
-  export default IWhyDidYouRender
+  export default IWhyDidYouRender;
 }
 
 declare namespace React {


### PR DESCRIPTION
When using Webpack to import `whyDidYouRender`, the default export type is wrong because it doesn't include the `defaultNotifier` property. This throws Typescript build errors that `defaultNotifier` is `undefined` if you try to access `whyDidYouRender.defaultNotifier`.

Fixed by including the `defaultNotifier` in default export type.