### PR TITLE
Various type improvements

### DIFF
--- a/tsx-test.tsx
+++ b/tsx-test.tsx
@@ -2,7 +2,7 @@
 import './types'
 import React from 'react'
 import * as Redux from 'react-redux'
-import whyDidYouRender, { WhyDidYouRender } from '.';
+import whyDidYouRender, { ExtraHookToTrack } from '.';
 
 /* SHOULD ERROR because bad trackExtraHooks was provided (second argument should be string) */
 whyDidYouRender(React, {trackExtraHooks: [[Redux, Redux.useSelector]]});
@@ -87,7 +87,7 @@ class ErrorousClassComponentWithTrackExtraHooks extends React.Component<Props>{
   static whyDidYouRender = {
     collapseGroups: true,
     /* SHOULD ERROR because bad trackExtraHooks was provided (second argument should be string) */
-    trackExtraHooks: [[Redux, Redux.useSelector] as WhyDidYouRender.ExtraHookToTrack]
+    trackExtraHooks: [[Redux, Redux.useSelector] as ExtraHookToTrack]
   }
   render(){
     const {str} = this.props
@@ -100,7 +100,7 @@ class ErrorousClassComponentWithTrackExtraHooks extends React.Component<Props>{
 class ClassComponentWithTrackExtraHooks extends React.Component<Props>{
   static whyDidYouRender = {
     collapseGroups: true,
-    trackExtraHooks: [[Redux, 'useSelector'] as WhyDidYouRender.ExtraHookToTrack]
+    trackExtraHooks: [[Redux, 'useSelector'] as ExtraHookToTrack]
   }
   render(){
     const {str} = this.props

--- a/tsx-test.tsx
+++ b/tsx-test.tsx
@@ -2,7 +2,7 @@
 import './types'
 import React from 'react'
 import * as Redux from 'react-redux'
-import whyDidYouRender from '@welldone-software/why-did-you-render';
+import whyDidYouRender, { WhyDidYouRender } from '.';
 
 /* SHOULD ERROR because bad trackExtraHooks was provided (second argument should be string) */
 whyDidYouRender(React, {trackExtraHooks: [[Redux, Redux.useSelector]]});

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,7 +1,6 @@
-/// <reference types="react" />
+import * as React from 'react';
 
-declare namespace WhyDidYouRender {
-
+export namespace WhyDidYouRender {
   interface HookDifference {
     pathString: string;
     diffType: string;
@@ -52,23 +51,21 @@ declare namespace WhyDidYouRender {
   type Notifier = (options: UpdateInfo) => void
 }
 
-declare module '@welldone-software/why-did-you-render' {
-  export import ReasonForUpdate = WhyDidYouRender.ReasonForUpdate;
-  export import UpdateInfo = WhyDidYouRender.UpdateInfo;
-  export import WhyDidYouRenderOptions = WhyDidYouRender.WhyDidYouRenderOptions;
-  export import HookDifference = WhyDidYouRender.HookDifference;
-  export import Notifier = WhyDidYouRender.Notifier;
+export import ReasonForUpdate = WhyDidYouRender.ReasonForUpdate;
+export import UpdateInfo = WhyDidYouRender.UpdateInfo;
+export import WhyDidYouRenderOptions = WhyDidYouRender.WhyDidYouRenderOptions;
+export import HookDifference = WhyDidYouRender.HookDifference;
+export import Notifier = WhyDidYouRender.Notifier;
 
-  function whyDidYouRender(react: typeof React, options?: WhyDidYouRenderOptions): typeof React;
+declare function whyDidYouRender(react: typeof React, options?: WhyDidYouRenderOptions): typeof React;
 
-  namespace whyDidYouRender {
-    export const defaultNotifier: Notifier;
-  }
-
-  export default whyDidYouRender;
+declare namespace whyDidYouRender {
+  export const defaultNotifier: Notifier;
 }
 
-declare namespace React {
+export default whyDidYouRender;
+
+declare module 'react' {
   interface FunctionComponent<P = {}> {
     whyDidYouRender?: WhyDidYouRender.WhyDidYouRenderComponentMember;
   }
@@ -82,12 +79,12 @@ declare namespace React {
   }
 
   /* not supported.
-   see https://github.com/microsoft/TypeScript/issues/33892
-   and https://github.com/microsoft/TypeScript/issues/34516
-   and https://github.com/microsoft/TypeScript/issues/32185
+  see https://github.com/microsoft/TypeScript/issues/33892
+  and https://github.com/microsoft/TypeScript/issues/34516
+  and https://github.com/microsoft/TypeScript/issues/32185
 
-   // interface Component<P = {}, S = {}, SS = any> extends ComponentLifecycle<P, S, SS> {
-   //   static whyDidYouRender?: WhyDidYouRender.WhyDidYouRenderComponentMember;
-   // }
+  // interface Component<P = {}, S = {}, SS = any> extends ComponentLifecycle<P, S, SS> {
+  //   static whyDidYouRender?: WhyDidYouRender.WhyDidYouRenderComponentMember;
+  // }
   */
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,61 +1,53 @@
 import * as React from 'react';
 
-export namespace WhyDidYouRender {
-  interface HookDifference {
-    pathString: string;
-    diffType: string;
-    prevValue: any;
-    nextValue: any;
-  }
-
-  interface ReasonForUpdate {
-    hookDifferences: HookDifference[];
-    propsDifferences: boolean;
-    stateDifferences: boolean;
-  }
-
-  interface UpdateInfo {
-    Component: React.Component;
-    displayName: string;
-    prevProps: any;
-    prevState: any;
-    nextProps: any;
-    nextState: any;
-    prevHook: any;
-    nextHook: any;
-    reason: ReasonForUpdate;
-    options: WhyDidYouRenderOptions;
-    hookName?: string;
-  }
-
-  type ExtraHookToTrack = [any, string];
-
-  interface WhyDidYouRenderOptions {
-    include?: RegExp[];
-    exclude?: RegExp[];
-    trackAllPureComponents?: boolean;
-    trackHooks?: boolean;
-    trackExtraHooks?: Array<ExtraHookToTrack>;
-    logOnDifferentValues?: boolean;
-    hotReloadBufferMs?: number;
-    onlyLogs?: boolean;
-    collapseGroups?: boolean;
-    titleColor?: string;
-    diffNameColor?: string;
-    diffPathColor?: string;
-    notifier?: Notifier;
-  }
-
-  type WhyDidYouRenderComponentMember = WhyDidYouRenderOptions|boolean
-  
-  type Notifier = (options: UpdateInfo) => void
+export interface HookDifference {
+  pathString: string;
+  diffType: string;
+  prevValue: any;
+  nextValue: any;
 }
 
-export import ReasonForUpdate = WhyDidYouRender.ReasonForUpdate;
-export import UpdateInfo = WhyDidYouRender.UpdateInfo;
-export import WhyDidYouRenderOptions = WhyDidYouRender.WhyDidYouRenderOptions;
-export import HookDifference = WhyDidYouRender.HookDifference;
-export import Notifier = WhyDidYouRender.Notifier;
+export interface ReasonForUpdate {
+  hookDifferences: HookDifference[];
+  propsDifferences: boolean;
+  stateDifferences: boolean;
+}
+
+export interface UpdateInfo {
+  Component: React.Component;
+  displayName: string;
+  prevProps: any;
+  prevState: any;
+  nextProps: any;
+  nextState: any;
+  prevHook: any;
+  nextHook: any;
+  reason: ReasonForUpdate;
+  options: WhyDidYouRenderOptions;
+  hookName?: string;
+}
+
+export type ExtraHookToTrack = [any, string];
+
+export interface WhyDidYouRenderOptions {
+  include?: RegExp[];
+  exclude?: RegExp[];
+  trackAllPureComponents?: boolean;
+  trackHooks?: boolean;
+  trackExtraHooks?: Array<ExtraHookToTrack>;
+  logOnDifferentValues?: boolean;
+  hotReloadBufferMs?: number;
+  onlyLogs?: boolean;
+  collapseGroups?: boolean;
+  titleColor?: string;
+  diffNameColor?: string;
+  diffPathColor?: string;
+  notifier?: Notifier;
+}
+
+export type WhyDidYouRenderComponentMember = WhyDidYouRenderOptions|boolean
+
+export type Notifier = (options: UpdateInfo) => void
 
 declare function whyDidYouRender(react: typeof React, options?: WhyDidYouRenderOptions): typeof React;
 
@@ -67,15 +59,15 @@ export default whyDidYouRender;
 
 declare module 'react' {
   interface FunctionComponent<P = {}> {
-    whyDidYouRender?: WhyDidYouRender.WhyDidYouRenderComponentMember;
+    whyDidYouRender?: WhyDidYouRenderComponentMember;
   }
 
   interface ExoticComponent<P = {}> {
-    whyDidYouRender?: WhyDidYouRender.WhyDidYouRenderComponentMember;
+    whyDidYouRender?: WhyDidYouRenderComponentMember;
   }
 
   namespace Component {
-    const whyDidYouRender: WhyDidYouRender.WhyDidYouRenderComponentMember;
+    const whyDidYouRender: WhyDidYouRenderComponentMember;
   }
 
   /* not supported.
@@ -84,7 +76,7 @@ declare module 'react' {
   and https://github.com/microsoft/TypeScript/issues/32185
 
   // interface Component<P = {}, S = {}, SS = any> extends ComponentLifecycle<P, S, SS> {
-  //   static whyDidYouRender?: WhyDidYouRender.WhyDidYouRenderComponentMember;
+  //   static whyDidYouRender?: WhyDidYouRenderComponentMember;
   // }
   */
 }


### PR DESCRIPTION
Currently the types create a global namespace called `React`, in order to augment the namespace created by the React types provided by the `react` module.

However, this has unintended side effects because of the particular way it is achieved. This module's types will:

- create a global namespace called `React` even when React hasn't been imported yet
- create a _global_ namespace called `React` if React has been imported as a _module_

We only want to _augment_ the React namespace—we don't want to create one if it doesn't exist yet.

As an example of why this matters, consider how TypeScript provides useful error messages if you forget to import React:

```ts
// Oops, we forgot to import React
// import * as React from 'react';

// TS error ✅ 
// 'React' refers to a UMD global, but the current file is a module. Consider adding an import instead.
export const el = <div>foo</div>;
```

We want this to error at compile time because otherwise we will have a runtime exception. [Example](https://stackblitz.com/edit/react-ts-8keicq?file=my-module.d.ts).

However, if a module (such as this one) declares a global namespace called React, this wouldn't error:

```ts
// Oops, we forgot to import React
// import * as React from 'react';

type T = typeof import('@welldone-software/why-did-you-render').default;

// No TS error ❌
// TypeScript thinks there is already a React namespace
export const el = <div>foo</div>;
```

This PR fixes that.

In order to fix this, I had to convert the types to using standard module syntax instead of `declare module`.