### PR TITLE
Fix handling derived hooks state with logOwnerReasons

### DIFF
--- a/src/whyDidYouRender.js
+++ b/src/whyDidYouRender.js
@@ -15,7 +15,12 @@ import {isForwardRefComponent, isMemoComponent, isReactClassComponent} from './u
 const initialHookValue = Symbol('initial-hook-value')
 function trackHookChanges(hookName, {path: hookPath}, hookResult, React, options, ownerDataMap, hooksRef){
   const nextHook = hookPath ? get(hookResult, hookPath) : hookResult
-  hooksRef.current.push({hookName, result: nextHook})
+  const renderNumber = React.useRef(1)
+  if(hooksRef.current[0] != null && renderNumber.current !== hooksRef.current[0].renderNumber){
+    hooksRef.current = []
+  }
+  hooksRef.current.push({hookName, result: nextHook, renderNumber: renderNumber.current})
+  renderNumber.current++
   const ComponentHookDispatchedFromInstance = (
     React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED &&
     React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ReactCurrentOwner.current

--- a/tests/logOwnerReasons.test.js
+++ b/tests/logOwnerReasons.test.js
@@ -132,6 +132,62 @@ describe('logOwnerReasons - function child', () => {
       }
     })
   })
+
+  test('owner state updated during render', () => {
+    function DerivedStateOwner({ready}){
+      const [wasReady, setWasReady] = React.useState(ready)
+      if(ready && !wasReady){
+        setWasReady(true)
+      }
+
+      return <Child />
+    }
+    const {rerender} = rtl.render(<DerivedStateOwner ready={false}/>)
+    rerender(<DerivedStateOwner ready/>)
+    rerender(<DerivedStateOwner ready={false}/>)
+
+    expect(updateInfos).toHaveLength(2)
+    expect(updateInfos[0].reason).toEqual({
+      propsDifferences: [],
+      stateDifferences: false,
+      hookDifferences: false,
+      ownerDifferences: {
+        propsDifferences: [{
+          pathString: 'ready',
+          diffType: diffTypes.different,
+          prevValue: false,
+          nextValue: true
+        }],
+        stateDifferences: false,
+        hookDifferences: [
+          {
+            hookName: 'useState',
+            differences: [{
+              pathString: '',
+              diffType: diffTypes.different,
+              prevValue: false,
+              nextValue: true
+            }]
+          }
+        ]
+      }
+    })
+    expect(updateInfos[1].reason).toEqual({
+      propsDifferences: [],
+      stateDifferences: false,
+      hookDifferences: false,
+      ownerDifferences: {
+        propsDifferences: [{
+          pathString: 'ready',
+          diffType: diffTypes.different,
+          prevValue: true,
+          nextValue: false
+        }],
+        stateDifferences: false,
+        hookDifferences: [{hookName: 'useState', differences: false}]
+      }
+    })
+  })
 })
 
 


### PR DESCRIPTION
Problem: if owner component updates its state during render, all its hooks are recorded twice, which leads to hooks count mismatch with subsequent and previous renders. This PR ensures that hooks array is reset on each render, including the ones caused by state updates during rendering (see https://reactjs.org/docs/hooks-faq.html#how-do-i-implement-getderivedstatefromprops for reasons why it can be needed)