### PR TITLE
👾 Include customName in WhyDidYouRenderOptions type

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -44,6 +44,7 @@ export interface WhyDidYouRenderOptions {
   diffNameColor?: string;
   diffPathColor?: string;
   notifier?: Notifier;
+  customName?: string;
 }
 
 export type WhyDidYouRenderComponentMember = WhyDidYouRenderOptions|boolean


### PR DESCRIPTION
At the moment I'm having to add my own module augmentation to use customName without typescript errors.

```ts
import '@welldone-software/why-did-you-render';
declare module '@welldone-software/why-did-you-render' {
  interface WhyDidYouRenderOptions {
    customName?: string;
  }
}
```