### PR TITLE
Splitting lodash into separated packages

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,4 +1,4 @@
-const compact = require('lodash/compact')
+const compact = require('lodash.compact')
 
 module.exports = function(api){
   const isProd = process.env.NODE_ENV === 'production'

--- a/demo/src/bigList/index.js
+++ b/demo/src/bigList/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import ReactDom from 'react-dom'
-import {times} from 'lodash'
+import times from 'lodash.times'
 
 export default {
   description: 'Big List (Main Demo)',

--- a/demo/src/reactRedux/index.js
+++ b/demo/src/reactRedux/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import ReactDom from 'react-dom'
-import _ from  'lodash'
+import cloneDeep from  'lodash.clonedeep'
 import {createStore} from 'redux'
 import * as Redux from 'react-redux'
 
@@ -38,7 +38,7 @@ export default {
         return {a: {b: `${Math.random()}`}}
       }
       if(action.type === 'deepEqlObj'){
-        return _.cloneDeep(state)
+        return cloneDeep(state)
       }
       return state
     })

--- a/demo/src/reactReduxHOC/index.js
+++ b/demo/src/reactReduxHOC/index.js
@@ -2,7 +2,7 @@ import React from 'react'
 import ReactDom from 'react-dom'
 import {createStore} from 'redux'
 import * as Redux from 'react-redux'
-import _ from  'lodash'
+import cloneDeep from  'lodash.clonedeep'
 
 const connect = Redux.connect
 const Provider = Redux.Provider
@@ -20,7 +20,7 @@ export default {
       }
 
       if(action.type === 'deepEqlObj'){
-        return _.cloneDeep(state)
+        return cloneDeep(state)
       }
 
       return state

--- a/package.json
+++ b/package.json
@@ -54,7 +54,23 @@
     ]
   },
   "dependencies": {
-    "lodash": "^4"
+    "lodash.times": "^4",
+    "lodash.sortby": "^4",
+    "lodash.compact": "^4",
+    "lodash.clonedeep": "^4",
+    "lodash.defaults": "^4",
+    "lodash.get": "^4",
+    "lodash.groupby": "^4",
+    "lodash.isarray": "^4",
+    "lodash.isplainobject": "^4",
+    "lodash.isdate": "^4",
+    "lodash.isregexp": "^4",
+    "lodash.isfunction": "^4",
+    "lodash.isset": "^4",
+    "lodash.isstring": "^4",
+    "lodash.keys": "^4",
+    "lodash.reduce": "^4",
+    "lodash.has": "^4"
   },
   "peerDependencies": {
     "react": "^16"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,7 +15,25 @@ Generated at <%= moment().format('YYYY-MM-DD') %>
 
 export default {
   input: 'src/index.js',
-  external: ['lodash'],
+  external: [
+    'lodash.times',
+    'lodash.sortby',
+    'lodash.compact',
+    'lodash.clonedeep',
+    'lodash.defaults',
+    'lodash.get',
+    'lodash.groupby',
+    'lodash.isarray',
+    'lodash.isplainobject',
+    'lodash.isdate',
+    'lodash.isregexp',
+    'lodash.isfunction',
+    'lodash.isset',
+    'lodash.isstring',
+    'lodash.keys',
+    'lodash.reduce',
+    'lodash.has',
+  ],
   output: [
     {
       name: 'whyDidYouRender',
@@ -24,7 +42,23 @@ export default {
       sourcemap: true,
       exports: 'default',
       globals: {
-        lodash: 'lodash'
+        'lodash.times':'times',
+        'lodash.sortby': 'sortBy',
+        'lodash.compact': 'compact',
+        'lodash.clonedeep': 'cloneDeep',
+        'lodash.defaults': 'defaults',
+        'lodash.get': 'get',
+        'lodash.groupby': 'groupBy',
+        'lodash.isarray': 'isArray',
+        'lodash.isplainobject': 'isPlainObject',
+        'lodash.isdate': 'isDate',
+        'lodash.isregexp': 'isRegexp',
+        'lodash.isfunction': 'isFunction',
+        'lodash.isset': 'isSet',
+        'lodash.isstring': 'isString',
+        'lodash.keys': 'keys',
+        'lodash.reduce': 'reduce',
+        'lodash.has': 'has',
       }
     }
   ],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -32,7 +32,7 @@ export default {
     'lodash.isstring',
     'lodash.keys',
     'lodash.reduce',
-    'lodash.has',
+    'lodash.has'
   ],
   output: [
     {
@@ -58,7 +58,7 @@ export default {
         'lodash.isstring': 'isString',
         'lodash.keys': 'keys',
         'lodash.reduce': 'reduce',
-        'lodash.has': 'has',
+        'lodash.has': 'has'
       }
     }
   ],

--- a/src/calculateDeepEqualDiffs.js
+++ b/src/calculateDeepEqualDiffs.js
@@ -1,4 +1,11 @@
-import {isArray, isPlainObject, isDate, isRegExp, isFunction, isSet, keys as getKeys, has} from 'lodash'
+import isArray from 'lodash.isarray'
+import isPlainObject from 'lodash.isplainobject'
+import isDate from 'lodash.isdate'
+import isRegExp from 'lodash.isregexp'
+import isFunction from 'lodash.isfunction'
+import isSet from 'lodash.isset'
+import getKeys from 'lodash.keys'
+import has from 'lodash.has'
 import {diffTypes} from './consts'
 
 const hasElementType = typeof Element !== 'undefined'

--- a/src/findObjectsDifferences.js
+++ b/src/findObjectsDifferences.js
@@ -1,4 +1,4 @@
-import {reduce} from 'lodash'
+import reduce from 'lodash.reduce'
 import calculateDeepEqualDiffs from './calculateDeepEqualDiffs'
 
 const emptyObject = {}

--- a/src/getDisplayName.js
+++ b/src/getDisplayName.js
@@ -1,4 +1,4 @@
-import {isString} from 'lodash'
+import isString from 'lodash.isstring'
 
 export default function getDisplayName(type){
   return (

--- a/src/patches/patchClassComponent.js
+++ b/src/patches/patchClassComponent.js
@@ -1,4 +1,4 @@
-import {defaults} from 'lodash'
+import defaults  from 'lodash.defaults'
 
 import {checkIfInsideAStrictModeTree} from '../utils'
 import getUpdateInfo from '../getUpdateInfo'

--- a/src/patches/patchForwardRefComponent.js
+++ b/src/patches/patchForwardRefComponent.js
@@ -1,4 +1,4 @@
-import {defaults} from 'lodash'
+import defaults  from 'lodash.defaults'
 
 import getDisplayName from '../getDisplayName'
 import {isMemoComponent} from '../utils'

--- a/src/patches/patchFunctionalOrStrComponent.js
+++ b/src/patches/patchFunctionalOrStrComponent.js
@@ -1,4 +1,4 @@
-import {defaults} from 'lodash'
+import defaults  from 'lodash.defaults'
 
 import getUpdateInfo from '../getUpdateInfo'
 

--- a/src/patches/patchMemoComponent.js
+++ b/src/patches/patchMemoComponent.js
@@ -1,4 +1,4 @@
-import {defaults} from 'lodash'
+import defaults from 'lodash.defaults'
 
 import getDisplayName from '../getDisplayName'
 

--- a/src/printDiff.js
+++ b/src/printDiff.js
@@ -1,4 +1,5 @@
-import {sortBy, groupBy} from 'lodash'
+import sortBy from 'lodash.sortby'
+import groupBy from 'lodash.groupby'
 import calculateDeepEqualDiffs from './calculateDeepEqualDiffs'
 import {diffTypesDescriptions} from './consts'
 

--- a/src/whyDidYouRender.js
+++ b/src/whyDidYouRender.js
@@ -1,4 +1,5 @@
-import {get, isFunction} from 'lodash'
+import get from 'lodash.get'
+import isFunction from 'lodash.isfunction'
 
 import normalizeOptions from './normalizeOptions'
 import getDisplayName from './getDisplayName'

--- a/tests/librariesTests/react-redux.test.js
+++ b/tests/librariesTests/react-redux.test.js
@@ -2,7 +2,7 @@ import React from 'react'
 import {createStore} from 'redux'
 import * as Redux from 'react-redux'
 import {connect, Provider} from 'react-redux'
-import {cloneDeep} from 'lodash'
+import cloneDeep from 'lodash.clonedeep'
 import * as rtl from '@testing-library/react'
 import {diffTypes} from 'consts'
 

--- a/tests/librariesTests/react-router-dom.test.js
+++ b/tests/librariesTests/react-router-dom.test.js
@@ -2,7 +2,7 @@ import React from 'react'
 import {createStore} from 'redux'
 import {BrowserRouter as Router, withRouter} from 'react-router-dom'
 import {connect, Provider} from 'react-redux'
-import {cloneDeep} from 'lodash'
+import cloneDeep from 'lodash.clonedeep'
 import * as rtl from '@testing-library/react'
 
 import whyDidYouRender from 'index'

--- a/yarn.lock
+++ b/yarn.lock
@@ -4965,22 +4965,102 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+lodash.clonedeep@^4:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+  integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
+
+lodash.compact@^4:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.compact/-/lodash.compact-3.0.1.tgz#540ce3837745975807471e16b4a2ba21e7256ca5"
+  integrity sha1-VAzjg3dFl1gHRx4WtKK6IeclbKU=
+
+lodash.defaults@^4:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
+  integrity sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=
+
+lodash.get@^4:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
+
+lodash.groupby@^4:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.groupby/-/lodash.groupby-4.6.0.tgz#0b08a1dcf68397c397855c3239783832df7403d1"
+  integrity sha1-Cwih3PaDl8OXhVwyOXg4Mt90A9E=
+
+lodash.has@^4:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/lodash.has/-/lodash.has-4.5.2.tgz#d19f4dc1095058cccbe2b0cdf4ee0fe4aa37c862"
+  integrity sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI=
+
+lodash.isarray@^4:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-4.0.0.tgz#2aca496b28c4ca6d726715313590c02e6ea34403"
+  integrity sha1-KspJayjEym1yZxUxNZDALm6jRAM=
+
+lodash.isdate@^4:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isdate/-/lodash.isdate-4.0.1.tgz#35a543673b9d76110de4114b32cc577048a7f366"
+  integrity sha1-NaVDZzuddhEN5BFLMsxXcEin82Y=
+
+lodash.isfunction@^4:
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz#06de25df4db327ac931981d1bdb067e5af68d051"
+  integrity sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==
+
+lodash.isplainobject@^4:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+  integrity sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=
+
+lodash.isregexp@^4:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isregexp/-/lodash.isregexp-4.0.1.tgz#e13e647b30cd559752a04cd912086faf7da1c30b"
+  integrity sha1-4T5kezDNVZdSoEzZEghvr32hwws=
+
+lodash.isset@^4:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.isset/-/lodash.isset-4.4.2.tgz#d5eecc56b7a97ab588509e4795b3541b1cdb67bb"
+  integrity sha1-1e7MVreperWIUJ5HlbNUGxzbZ7s=
+
+lodash.isstring@^4:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+  integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
+
+lodash.keys@^4:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-4.2.0.tgz#a08602ac12e4fb83f91fc1fb7a360a4d9ba35205"
+  integrity sha1-oIYCrBLk+4P5H8H7ejYKTZujUgU=
+
 lodash.once@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
   integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
 
-lodash.sortby@^4.7.0:
+lodash.reduce@^4:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.reduce/-/lodash.reduce-4.6.0.tgz#f1ab6b839299ad48f784abbf476596f03b914d3b"
+  integrity sha1-8atrg5KZrUj3hKu/R2WW8DuRTTs=
+
+lodash.sortby@^4, lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
+
+lodash.times@^4:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/lodash.times/-/lodash.times-4.3.2.tgz#3e1f2565c431754d54ab57f2ed1741939285ca1d"
+  integrity sha1-Ph8lZcQxdU1Uq1fy7RdBk5KFyh0=
 
 lodash@4.17.19:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
-lodash@^4, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19:
+lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==


### PR DESCRIPTION
### What's done
Removed `lodash` from dependencies, added:
```
    "lodash.times": "^4",
    "lodash.sortby": "^4",
    "lodash.compact": "^4",
    "lodash.clonedeep": "^4",
    "lodash.defaults": "^4",
    "lodash.get": "^4",
    "lodash.groupby": "^4",
    "lodash.isarray": "^4",
    "lodash.isplainobject": "^4",
    "lodash.isdate": "^4",
    "lodash.isregexp": "^4",
    "lodash.isfunction": "^4",
    "lodash.isset": "^4",
    "lodash.isstring": "^4",
    "lodash.keys": "^4",
    "lodash.reduce": "^4",
    "lodash.has": "^4"
```
That covers all lodash imports.

### Technical explanation
Why-did-you-render is too heavy because the whole lodash was imported.