### PR TITLE
support non plain objects

### DIFF
--- a/src/calculateDeepEqualDiffs.js
+++ b/src/calculateDeepEqualDiffs.js
@@ -127,16 +127,18 @@ function accumulateDeepEqualDiffs(a, b, diffsAccumulator, pathString = '', { det
     return trackDiff(a, b, diffsAccumulator, pathString, diffTypes.function);
   }
 
-  if (isPlainObject(a) && isPlainObject(b)) {
+  if (isPlainObject(a) && isPlainObject(b) || typeof a === 'object' && Object.getPrototypeOf(a) === Object.getPrototypeOf(b)) {
     const keys = getKeys(a);
     const keysLength = keys.length;
+    const clonedA = isPlainObject(a) ? { ...a } : a;
+    const clonedB = isPlainObject(b) ? { ...b } : b;
     if (keysLength !== getKeys(b).length) {
-      return trackDiff({ ...a }, { ...b }, diffsAccumulator, pathString, diffTypes.different);
+      return trackDiff(clonedA, clonedB, diffsAccumulator, pathString, diffTypes.different);
     }
 
     for (let i = keysLength; i--; i > 0) {
       if (!has(b, keys[i])) {
-        return trackDiff({ ...a }, { ...b }, diffsAccumulator, pathString, diffTypes.different);
+        return trackDiff(clonedA, clonedB, diffsAccumulator, pathString, diffTypes.different);
       }
     }
 
@@ -155,10 +157,10 @@ function accumulateDeepEqualDiffs(a, b, diffsAccumulator, pathString = '', { det
     }
 
     if (numberOfDeepEqualsObjectValues === keysLength) {
-      return trackDiff({ ...a }, { ...b }, diffsAccumulator, pathString, diffTypes.deepEquals);
+      return trackDiff(clonedA, clonedB, diffsAccumulator, pathString, diffTypes.deepEquals);
     }
 
-    return trackDiff({ ...a }, { ...b }, diffsAccumulator, pathString, diffTypes.different);
+    return trackDiff(clonedA, clonedB, diffsAccumulator, pathString, diffTypes.different);
   }
 
   return trackDiff(a, b, diffsAccumulator, pathString, diffTypes.different);

--- a/src/calculateDeepEqualDiffs.js
+++ b/src/calculateDeepEqualDiffs.js
@@ -127,7 +127,6 @@ function accumulateDeepEqualDiffs(a, b, diffsAccumulator, pathString = '', { det
     return trackDiff(a, b, diffsAccumulator, pathString, diffTypes.function);
   }
 
-  // if (isPlainObject(a) && isPlainObject(b)) {
   if (typeof a === 'object' && typeof b === 'object' && Object.getPrototypeOf(a) === Object.getPrototypeOf(b)) {
     const keys = Object.getOwnPropertyNames(a);
     const keysLength = keys.length;

--- a/src/calculateDeepEqualDiffs.js
+++ b/src/calculateDeepEqualDiffs.js
@@ -127,7 +127,7 @@ function accumulateDeepEqualDiffs(a, b, diffsAccumulator, pathString = '', { det
     return trackDiff(a, b, diffsAccumulator, pathString, diffTypes.function);
   }
 
-  if (isPlainObject(a) && isPlainObject(b) || typeof a === 'object' && Object.getPrototypeOf(a) === Object.getPrototypeOf(b)) {
+  if (typeof a === 'object' && typeof b === 'object' && Object.getPrototypeOf(a) === Object.getPrototypeOf(b)) {
     const keys = getKeys(a);
     const keysLength = keys.length;
     const clonedA = isPlainObject(a) ? { ...a } : a;

--- a/src/calculateDeepEqualDiffs.js
+++ b/src/calculateDeepEqualDiffs.js
@@ -1,7 +1,7 @@
 import {
   isArray, isPlainObject, isDate,
   isRegExp, isFunction, isSet,
-  keys as getKeys, has,
+  has,
 } from 'lodash';
 
 import { diffTypes } from './consts';
@@ -127,12 +127,13 @@ function accumulateDeepEqualDiffs(a, b, diffsAccumulator, pathString = '', { det
     return trackDiff(a, b, diffsAccumulator, pathString, diffTypes.function);
   }
 
+  // if (isPlainObject(a) && isPlainObject(b)) {
   if (typeof a === 'object' && typeof b === 'object' && Object.getPrototypeOf(a) === Object.getPrototypeOf(b)) {
-    const keys = getKeys(a);
+    const keys = Object.getOwnPropertyNames(a);
     const keysLength = keys.length;
     const clonedA = isPlainObject(a) ? { ...a } : a;
     const clonedB = isPlainObject(b) ? { ...b } : b;
-    if (keysLength !== getKeys(b).length) {
+    if (keysLength !== Object.getOwnPropertyNames(b).length) {
       return trackDiff(clonedA, clonedB, diffsAccumulator, pathString, diffTypes.different);
     }
 

--- a/tests/calculateDeepEqualDiffs.test.js
+++ b/tests/calculateDeepEqualDiffs.test.js
@@ -460,9 +460,12 @@ test('mix', () => {
   ]);
 });
 
-test('Error', () => {
+test('Equal Errors', () => {
+  const sharedStack = new Error().stack;
   const prevValue = new Error('message');
   const nextValue = new Error('message');
+  prevValue.stack = sharedStack;
+  nextValue.stack = sharedStack;
   const diffs = calculateDeepEqualDiffs(prevValue, nextValue);
   expect(diffs).toEqual([
     {
@@ -470,6 +473,79 @@ test('Error', () => {
       prevValue,
       nextValue,
       diffType: diffTypes.deepEquals,
+    },
+  ]);
+});
+
+test('Different Errors', () => {
+  const sharedStack = new Error().stack;
+  const prevValue = new Error('message');
+  const nextValue = new Error('Second message');
+  prevValue.stack = sharedStack;
+  nextValue.stack = sharedStack;
+  const diffs = calculateDeepEqualDiffs(prevValue, nextValue);
+  expect(diffs).toEqual([
+    {
+      pathString: '.message',
+      prevValue: 'message',
+      nextValue: 'Second message',
+      diffType: diffTypes.different,
+    },
+    {
+      pathString: '',
+      prevValue,
+      nextValue,
+      diffType: diffTypes.different,
+    },
+  ]);
+});
+
+test('Equal class instances', () => {
+  class Person {
+    constructor(name) {
+      this.name = name;
+    }
+  }
+  
+  const prevValue = new Person('Jon Snow');
+  const nextValue = new Person('Jon Snow');
+  const diffs = calculateDeepEqualDiffs(prevValue, nextValue);
+  expect(diffs).toEqual([
+    {
+      pathString: '',
+      prevValue,
+      nextValue,
+      diffType: diffTypes.deepEquals,
+    },
+  ]);
+});
+
+test('Different class instances', () => {
+  class Person {
+    constructor(name) {
+      this.name = name;
+    }
+  }
+  
+  const prevValue = new Person('Jon Snow');
+  const nextValue = new Person('Aria Stark');
+  const diffs = calculateDeepEqualDiffs(prevValue, nextValue);
+  expect(diffs).toEqual([
+    {
+      pathString: '.name',
+      prevValue: 'Jon Snow',
+      nextValue: 'Aria Stark',
+      diffType: diffTypes.different,
+    },
+    {
+      pathString: '',
+      prevValue: {
+        name: 'Jon Snow',
+      },
+      nextValue: {
+        name: 'Aria Stark',
+      },
+      diffType: diffTypes.different,
     },
   ]);
 });

--- a/tests/calculateDeepEqualDiffs.test.js
+++ b/tests/calculateDeepEqualDiffs.test.js
@@ -459,3 +459,17 @@ test('mix', () => {
     },
   ]);
 });
+
+test('Error', () => {
+  const prevValue = new Error('message');
+  const nextValue = new Error('message');
+  const diffs = calculateDeepEqualDiffs(prevValue, nextValue);
+  expect(diffs).toEqual([
+    {
+      pathString: '',
+      prevValue,
+      nextValue,
+      diffType: diffTypes.deepEquals,
+    },
+  ]);
+});

--- a/tests/calculateDeepEqualDiffs.test.js
+++ b/tests/calculateDeepEqualDiffs.test.js
@@ -459,46 +459,92 @@ test('mix', () => {
     },
   ]);
 });
+describe('calculateDeepEqualDiffs - Errors', () => {
+  test('Equal Native Errors', () => {
+    const prevValue = new Error('message');
+    const nextValue = new Error('message');
+    const diffs = calculateDeepEqualDiffs(prevValue, nextValue);
+    expect(diffs).toEqual([
+      {
+        pathString: '',
+        prevValue,
+        nextValue,
+        diffType: diffTypes.deepEquals,
+      },
+    ]);
+  });
+  
+  test('Different Native Errors', () => {
+    const prevValue = new Error('message');
+    const nextValue = new Error('Second message');
+    const diffs = calculateDeepEqualDiffs(prevValue, nextValue);
+    expect(diffs).toEqual([
+      {
+        pathString: '.message',
+        prevValue: 'message',
+        nextValue: 'Second message',
+        diffType: diffTypes.different,
+      },
+      {
+        pathString: '',
+        prevValue,
+        nextValue,
+        diffType: diffTypes.different,
+      },
+    ]);
+  });
 
-test('Equal Errors', () => {
-  const sharedStack = new Error().stack;
-  const prevValue = new Error('message');
-  const nextValue = new Error('message');
-  prevValue.stack = sharedStack;
-  nextValue.stack = sharedStack;
-  const diffs = calculateDeepEqualDiffs(prevValue, nextValue);
-  expect(diffs).toEqual([
-    {
-      pathString: '',
-      prevValue,
-      nextValue,
-      diffType: diffTypes.deepEquals,
-    },
-  ]);
+  test('Equal Custom Errors', () => {
+    class CustomError extends Error {
+      constructor(message, code) {
+        super(message);
+        this.name = 'ValidationError';
+        this.code = code;
+      }
+    }
+
+    const prevValue = new CustomError('message', 1001);
+    const nextValue = new CustomError('message', 1001);
+    const diffs = calculateDeepEqualDiffs(prevValue, nextValue);
+    expect(diffs).toEqual([
+      {
+        pathString: '',
+        prevValue,
+        nextValue,
+        diffType: diffTypes.deepEquals,
+      },
+    ]);
+  });
+
+  test('Different Custom Errors', () => {
+    class CustomError extends Error {
+      constructor(message, code) {
+        super(message);
+        this.name = 'ValidationError';
+        this.code = code;
+      }
+    }
+
+    const prevValue = new CustomError('message', 1001);
+    const nextValue = new CustomError('message', 1002);
+    const diffs = calculateDeepEqualDiffs(prevValue, nextValue);
+    expect(diffs).toEqual([
+      {
+        pathString: '.code',
+        prevValue: 1001,
+        nextValue: 1002,
+        diffType: diffTypes.different,
+      },
+      {
+        pathString: '',
+        prevValue,
+        nextValue,
+        diffType: diffTypes.different,
+      },
+    ]);
+  });
 });
 
-test('Different Errors', () => {
-  const sharedStack = new Error().stack;
-  const prevValue = new Error('message');
-  const nextValue = new Error('Second message');
-  prevValue.stack = sharedStack;
-  nextValue.stack = sharedStack;
-  const diffs = calculateDeepEqualDiffs(prevValue, nextValue);
-  expect(diffs).toEqual([
-    {
-      pathString: '.message',
-      prevValue: 'message',
-      nextValue: 'Second message',
-      diffType: diffTypes.different,
-    },
-    {
-      pathString: '',
-      prevValue,
-      nextValue,
-      diffType: diffTypes.different,
-    },
-  ]);
-});
 
 test('Equal class instances', () => {
   class Person {

--- a/tests/logOnDifferentValues.test.js
+++ b/tests/logOnDifferentValues.test.js
@@ -57,3 +57,42 @@ test('hook value change', () => {
     expect.objectContaining({ displayName: 'Foo' }),
   ]);
 });
+
+test('Non simple objects', () => {
+  const Foo = React.memo(function Foo({ error }) {
+    return (
+      <div>
+        <h1>{error.message}</h1>
+        <p>{error.stack}</p>
+      </div>
+    );
+  });
+
+  const App = React.memo(function App() {
+    const [text, setText] = React.useState('Click me');
+
+    return (
+      <div className="App">
+        <button
+          onClick={() => setText(state => state + '.')}
+          data-testid="button"
+        >
+          {text}
+        </button>
+        <hr/>
+        <Foo error={new Error('message')}/>
+      </div>
+    );
+  });
+
+  const { getByTestId } = rtl.render(
+    <App/>
+  );
+
+  const button = getByTestId('button');
+  rtl.fireEvent.click(button);
+
+  expect(updateInfos[1].reason.propsDifferences[0]).toEqual(
+    expect.objectContaining({ diffType: 'deepEquals', 'pathString': 'error' }),
+  );
+});


### PR DESCRIPTION
Added non plain object detection:
1. Verify prototypes are equal.
2. Verify all keys are the same.

Wasn't sure why there's a copy of the object before sending it to `trackDiff` ([introduced here](https://github.com/welldone-software/why-did-you-render/commit/7235e62dbed1e9700a7a55563cb555d2a6b16eec)).
This broke for non plain objects, so I passed the object without clone in case it's not a plain one. Open for other suggestions here :)

This PR fixes https://github.com/welldone-software/why-did-you-render/issues/74

