### PR TITLE
Fix #193 - Pass defaultProps to patched components when applicable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@welldone-software/why-did-you-render",
-  "version": "6.1.2",
+  "version": "6.1.1",
   "description": "Monkey patches React to notify you about avoidable re-renders.",
   "types": "types.d.ts",
   "main": "dist/whyDidYouRender.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@welldone-software/why-did-you-render",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "description": "Monkey patches React to notify you about avoidable re-renders.",
   "types": "types.d.ts",
   "main": "dist/whyDidYouRender.js",

--- a/src/getDefaultProps.js
+++ b/src/getDefaultProps.js
@@ -1,0 +1,8 @@
+export default function getDefaultProps(type) {
+  return (
+    type.defaultProps ||
+    (type.type && getDefaultProps(type.type)) ||
+    (type.render && getDefaultProps(type.render)) ||
+    {}
+  );
+}

--- a/src/patches/patchClassComponent.js
+++ b/src/patches/patchClassComponent.js
@@ -5,7 +5,7 @@ import wdyrStore from '../wdyrStore';
 import { checkIfInsideAStrictModeTree } from '../utils';
 import getUpdateInfo from '../getUpdateInfo';
 
-export default function patchClassComponent(ClassComponent, { displayName }) {
+export default function patchClassComponent(ClassComponent, { displayName, defaultProps }) {
   class WDYRPatchedClassComponent extends ClassComponent {
     constructor(props, context) {
       super(props, context);
@@ -60,6 +60,8 @@ export default function patchClassComponent(ClassComponent, { displayName }) {
   } catch (e) {
     // not crucial if displayName couldn't be set
   }
+
+  WDYRPatchedClassComponent.defaultProps = defaultProps;
 
   defaults(WDYRPatchedClassComponent, ClassComponent);
 

--- a/src/patches/patchForwardRefComponent.js
+++ b/src/patches/patchForwardRefComponent.js
@@ -6,7 +6,7 @@ import getDisplayName from '../getDisplayName';
 import { isMemoComponent } from '../utils';
 import patchFunctionalOrStrComponent from './patchFunctionalOrStrComponent';
 
-export default function patchForwardRefComponent(ForwardRefComponent, { displayName }) {
+export default function patchForwardRefComponent(ForwardRefComponent, { displayName, defaultProps }) {
   const { render: InnerForwardRefComponent } = ForwardRefComponent;
 
   const isInnerComponentMemoized = isMemoComponent(InnerForwardRefComponent);
@@ -32,6 +32,8 @@ export default function patchForwardRefComponent(ForwardRefComponent, { displayN
   } catch (e) {
     // not crucial if displayName couldn't be set
   }
+
+  WDYRForwardRefFunctionalComponent.defaultProps = defaultProps;
 
   defaults(WDYRForwardRefFunctionalComponent, ForwardRefComponent);
 

--- a/src/patches/patchFunctionalOrStrComponent.js
+++ b/src/patches/patchFunctionalOrStrComponent.js
@@ -8,7 +8,7 @@ const getFunctionalComponentFromStringComponent = (componentTypeStr) => props =>
   wdyrStore.React.createElement(componentTypeStr, props)
 );
 
-export default function patchFunctionalOrStrComponent(FunctionalOrStringComponent, { isPure, displayName }) {
+export default function patchFunctionalOrStrComponent(FunctionalOrStringComponent, { isPure, displayName, defaultProps }) {
   const FunctionalComponent = typeof(FunctionalOrStringComponent) === 'string' ?
     getFunctionalComponentFromStringComponent(FunctionalOrStringComponent) :
     FunctionalOrStringComponent;
@@ -47,6 +47,8 @@ export default function patchFunctionalOrStrComponent(FunctionalOrStringComponen
   } catch (e) {
     // not crucial if displayName couldn't be set
   }
+
+  WDYRFunctionalComponent.defaultProps = defaultProps;
 
   WDYRFunctionalComponent.ComponentForHooksTracking = FunctionalComponent;
   defaults(WDYRFunctionalComponent, FunctionalComponent);

--- a/src/patches/patchMemoComponent.js
+++ b/src/patches/patchMemoComponent.js
@@ -7,7 +7,7 @@ import { isForwardRefComponent, isMemoComponent, isReactClassComponent } from '.
 import patchClassComponent from './patchClassComponent';
 import patchFunctionalOrStrComponent from './patchFunctionalOrStrComponent';
 
-export default function patchMemoComponent(MemoComponent, { displayName }) {
+export default function patchMemoComponent(MemoComponent, { displayName, defaultProps }) {
   const { type: InnerMemoComponent } = MemoComponent;
 
   const isInnerMemoComponentAClassComponent = isReactClassComponent(InnerMemoComponent);
@@ -19,9 +19,9 @@ export default function patchMemoComponent(MemoComponent, { displayName }) {
     InnerMemoComponent;
 
   const PatchedInnerComponent = isInnerMemoComponentAClassComponent ?
-    patchClassComponent(WrappedFunctionalComponent, { displayName }) :
+    patchClassComponent(WrappedFunctionalComponent, { displayName, defaultProps }) :
     (isInnerMemoComponentAnotherMemoComponent ?
-      patchMemoComponent(WrappedFunctionalComponent, { displayName }) :
+      patchMemoComponent(WrappedFunctionalComponent, { displayName, defaultProps }) :
       patchFunctionalOrStrComponent(WrappedFunctionalComponent, { displayName, isPure: true })
     );
 
@@ -44,6 +44,8 @@ export default function patchMemoComponent(MemoComponent, { displayName }) {
   } catch (e) {
     // not crucial if displayName couldn't be set
   }
+
+  WDYRMemoizedFunctionalComponent.defaultProps = defaultProps;
 
   defaults(WDYRMemoizedFunctionalComponent, MemoComponent);
 

--- a/src/whyDidYouRender.js
+++ b/src/whyDidYouRender.js
@@ -4,6 +4,7 @@ import wdyrStore from './wdyrStore';
 
 import normalizeOptions from './normalizeOptions';
 import getDisplayName from './getDisplayName';
+import getDefaultProps from './getDefaultProps';
 import getUpdateInfo from './getUpdateInfo';
 import shouldTrack from './shouldTrack';
 
@@ -77,28 +78,28 @@ function trackHookChanges(hookName, { path: hookPath }, hookResult) {
   return hookResult;
 }
 
-function createPatchedComponent(Component, { displayName }) {
+function createPatchedComponent(Component, { displayName, defaultProps }) {
   if (isMemoComponent(Component)) {
-    return patchMemoComponent(Component, { displayName });
+    return patchMemoComponent(Component, { displayName, defaultProps });
   }
 
   if (isForwardRefComponent(Component)) {
-    return patchForwardRefComponent(Component, { displayName });
+    return patchForwardRefComponent(Component, { displayName, defaultProps });
   }
 
   if (isReactClassComponent(Component)) {
-    return patchClassComponent(Component, { displayName });
+    return patchClassComponent(Component, { displayName, defaultProps });
   }
 
-  return patchFunctionalOrStrComponent(Component, { displayName, isPure: false });
+  return patchFunctionalOrStrComponent(Component, { displayName, defaultProps, isPure: false });
 }
 
-function getPatchedComponent(Component, { displayName }) {
+function getPatchedComponent(Component, { displayName, defaultProps }) {
   if (wdyrStore.componentsMap.has(Component)) {
     return wdyrStore.componentsMap.get(Component);
   }
 
-  const WDYRPatchedComponent = createPatchedComponent(Component, { displayName });
+  const WDYRPatchedComponent = createPatchedComponent(Component, { displayName, defaultProps });
 
   wdyrStore.componentsMap.set(Component, WDYRPatchedComponent);
 
@@ -215,7 +216,9 @@ export function getWDYRType(origType) {
     getDisplayName(origType)
   );
 
-  const WDYRPatchedComponent = getPatchedComponent(origType, { displayName });
+  const defaultProps = getDefaultProps(origType);
+
+  const WDYRPatchedComponent = getPatchedComponent(origType, { displayName, defaultProps });
 
   return WDYRPatchedComponent;
 }


### PR DESCRIPTION
`defaultProps` are lost on components patched by `wdyr`, this passes them along. All tests are passing and it seems to have solved my problem when using this version locally. This may want to be combined with adding `propTypes`. I can do that either in a different pull request or in this one. It should be basically the same process.