### PR TITLE
Add delegate parameter to allow for harvesting additional data from react element

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ Controls the colors used in the console notifications
 
 You can create a custom notifier if the default one does not suite your needs.
 
-#### getAddititionalOwnerData
+#### getAdditionalOwnerData
 ##### (default: undefined)
 You can provide a function that harvests additional data from the original react element. The object returned from this function will be added to the ownerDataMap which can be accessed later within your notifier function override.
 

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Optionally you can pass in `options` as the second parameter. The following opti
 - `diffNameColor`
 - `diffPathColor`
 - `notifier: ({Component, displayName, hookName, prevProps, prevState, prevHook, nextProps, nextState, nextHook, reason, options, ownerDataMap}) => void`
+- `getAdditionalOwnerData: (element) => {...}`
 
 #### include / exclude
 ##### (default: `null`)
@@ -292,7 +293,7 @@ Controls the colors used in the console notifications
 You can create a custom notifier if the default one does not suite your needs.
 
 #### getAdditionalOwnerData
-##### (default: undefined)
+##### (default: `undefined`)
 You can provide a function that harvests additional data from the original react element. The object returned from this function will be added to the ownerDataMap which can be accessed later within your notifier function override.
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -291,6 +291,10 @@ Controls the colors used in the console notifications
 
 You can create a custom notifier if the default one does not suite your needs.
 
+#### getAddititionalOwnerData
+##### (default: undefined)
+You can provide a function that harvests additional data from the original react element. The object returned from this function will be added to the ownerDataMap which can be accessed later within your notifier function override.
+
 ## Troubleshooting
 
 ### No tracking

--- a/src/whyDidYouRender.js
+++ b/src/whyDidYouRender.js
@@ -139,8 +139,8 @@ export function storeOwnerData(element) {
     const displayName = getDisplayName(Component);
 
     let additionalOwnerData = {};
-    if (wdyrStore.options.getAddititionalOwnerData) {
-      additionalOwnerData = wdyrStore.options.getAddititionalOwnerData(element);
+    if (wdyrStore.options.getAdditionalOwnerData) {
+      additionalOwnerData = wdyrStore.options.getAdditionalOwnerData(element);
     }
 
     wdyrStore.ownerDataMap.set(element.props, {

--- a/src/whyDidYouRender.js
+++ b/src/whyDidYouRender.js
@@ -137,12 +137,19 @@ export function storeOwnerData(element) {
   if (OwnerInstance) {
     const Component = OwnerInstance.type.ComponentForHooksTracking || OwnerInstance.type;
     const displayName = getDisplayName(Component);
+
+    let additionalOwnerData = {};
+    if (wdyrStore.options.getAddititionalOwnerData) {
+      additionalOwnerData = wdyrStore.options.getAddititionalOwnerData(element);
+    }
+
     wdyrStore.ownerDataMap.set(element.props, {
       Component,
       displayName,
       props: OwnerInstance.pendingProps,
       state: OwnerInstance.stateNode ? OwnerInstance.stateNode.state : null,
       hooks: wdyrStore.hooksPerRender,
+      ...additionalOwnerData
     });
   }
 }

--- a/src/whyDidYouRender.js
+++ b/src/whyDidYouRender.js
@@ -149,7 +149,7 @@ export function storeOwnerData(element) {
       props: OwnerInstance.pendingProps,
       state: OwnerInstance.stateNode ? OwnerInstance.stateNode.state : null,
       hooks: wdyrStore.hooksPerRender,
-      ...additionalOwnerData
+      additionalOwnerData,
     });
   }
 }


### PR DESCRIPTION
In an effort to expose the _nativeTag on the element, I need access to the raw react element, most easily accessed in the 'storeOwnerData' function. Created an optional delegate parameter to access the raw element and return additional data in a returned object, which is stored in the ownerDataMap to be referenced later. 

With this change, in combination with my 'notifier' override adding this data to the 'displayName', I am able to identify my native elements via their closest relative native Id (which can be used to correlate wdyr to my ReactNative UI elements).

![image](https://user-images.githubusercontent.com/45570213/121053270-07705900-c770-11eb-84f1-bb03172a94ff.png)
