### PR TITLE
Add wdyr to VFC type

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -64,6 +64,10 @@ declare module 'react' {
     whyDidYouRender?: WhyDidYouRenderComponentMember;
   }
 
+  interface VoidFunctionComponent<P = {}> {
+    whyDidYouRender?: WhyDidYouRenderComponentMember;
+  }
+
   interface ExoticComponent<P = {}> {
     whyDidYouRender?: WhyDidYouRenderComponentMember;
   }


### PR DESCRIPTION
React 16.9.48 added a VFC type with no automatically added children prop.  This allows for no children, or more accurately type children to be used in components.

This PR adds the WDYR definition to the VFC typing.