### PR TITLE
Fix package.json peerDependencies entry for "react" with correct OR condition

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "lodash": "^4"
   },
   "peerDependencies": {
-    "react": "^16 || ^17 | ^18"
+    "react": "^16 || ^17 || ^18"
   },
   "devDependencies": {
     "@babel/cli": "^7.17.6",


### PR DESCRIPTION
This is just:
```
    "react": "^16 || ^17 | ^18"
```

...to:
```
    "react": "^16 || ^17 || ^18"
```

Fixes #241 