### PR TITLE
Add opaqueOverride option to prop object handling

### DIFF
--- a/src/calculateDeepEqualDiffs.js
+++ b/src/calculateDeepEqualDiffs.js
@@ -42,7 +42,19 @@ function isGetter(obj, prop) {
 
 export const dependenciesMap = new WeakMap();
 
-function accumulateDeepEqualDiffs(a, b, diffsAccumulator, pathString = '', {detailed}) {
+function accumulateDeepEqualDiffs(a, b, diffsAccumulator, pathString = '', {detailed, opaqueOverride}) {
+  // Check if either value should be treated as opaque
+  if (opaqueOverride) {
+    const aIsOpaque = opaqueOverride(a);
+    const bIsOpaque = opaqueOverride(b);
+    if (aIsOpaque || bIsOpaque) {
+      // If either is opaque, only compare by reference
+      return a === b ? 
+        trackDiff(a, b, diffsAccumulator, pathString, diffTypes.same) :
+        trackDiff(a, b, diffsAccumulator, pathString, diffTypes.different);
+    }
+  }
+
   if (a === b) {
     if (detailed) {
       trackDiff(a, b, diffsAccumulator, pathString, diffTypes.same);
@@ -63,7 +75,7 @@ function accumulateDeepEqualDiffs(a, b, diffsAccumulator, pathString = '', {deta
     const arrayItemDiffs = [];
     let numberOfDeepEqualsItems = 0;
     for (let i = arrayLength; i--; i > 0) {
-      const diffEquals = accumulateDeepEqualDiffs(a[i], b[i], arrayItemDiffs, `${pathString}[${i}]`, {detailed});
+      const diffEquals = accumulateDeepEqualDiffs(a[i], b[i], arrayItemDiffs, `${pathString}[${i}]`, {detailed, opaqueOverride});
       if (diffEquals) {
         numberOfDeepEqualsItems++;
       }
@@ -116,7 +128,7 @@ function accumulateDeepEqualDiffs(a, b, diffsAccumulator, pathString = '', {deta
     }
 
     const reactElementPropsAreDeepEqual =
-      accumulateDeepEqualDiffs(a.props, b.props, [], `${pathString}.props`, {detailed});
+      accumulateDeepEqualDiffs(a.props, b.props, [], `${pathString}.props`, {detailed, opaqueOverride});
 
     return reactElementPropsAreDeepEqual ?
       trackDiff(a, b, diffsAccumulator, pathString, diffTypes.reactElement) :
@@ -133,7 +145,7 @@ function accumulateDeepEqualDiffs(a, b, diffsAccumulator, pathString = '', {deta
 
     if (aDependenciesObj && bDependenciesObj) {
       const dependenciesAreDeepEqual =
-        accumulateDeepEqualDiffs(aDependenciesObj.deps, bDependenciesObj.deps, diffsAccumulator, `${pathString}:parent-hook-${aDependenciesObj.hookName}-deps`, {detailed});
+        accumulateDeepEqualDiffs(aDependenciesObj.deps, bDependenciesObj.deps, diffsAccumulator, `${pathString}:parent-hook-${aDependenciesObj.hookName}-deps`, {detailed, opaqueOverride});
 
       return dependenciesAreDeepEqual ?
         trackDiff(a, b, diffsAccumulator, pathString, diffTypes.function) :
@@ -144,6 +156,7 @@ function accumulateDeepEqualDiffs(a, b, diffsAccumulator, pathString = '', {deta
   }
 
   if (typeof a === 'object' && typeof b === 'object' && Object.getPrototypeOf(a) === Object.getPrototypeOf(b)) {
+    
     const aKeys = Object.getOwnPropertyNames(a);
     const bKeys = Object.getOwnPropertyNames(b);
     
@@ -183,7 +196,7 @@ function accumulateDeepEqualDiffs(a, b, diffsAccumulator, pathString = '', {deta
     let numberOfDeepEqualsObjectValues = 0;
     for (let i = keysLength; i--; i > 0) {
       const key = relevantKeys[i];
-      const deepEquals = accumulateDeepEqualDiffs(a[key], b[key], objectValuesDiffs, `${pathString}.${key}`, {detailed});
+      const deepEquals = accumulateDeepEqualDiffs(a[key], b[key], objectValuesDiffs, `${pathString}.${key}`, {detailed, opaqueOverride});
       if (deepEquals) {
         numberOfDeepEqualsObjectValues++;
       }
@@ -203,10 +216,10 @@ function accumulateDeepEqualDiffs(a, b, diffsAccumulator, pathString = '', {deta
   return trackDiff(a, b, diffsAccumulator, pathString, diffTypes.different);
 }
 
-export default function calculateDeepEqualDiffs(a, b, initialPathString, {detailed = false} = {}) {
+export default function calculateDeepEqualDiffs(a, b, initialPathString, {detailed = false, opaqueOverride} = {}) {
   try {
     const diffs = [];
-    accumulateDeepEqualDiffs(a, b, diffs, initialPathString, {detailed});
+    accumulateDeepEqualDiffs(a, b, diffs, initialPathString, {detailed, opaqueOverride});
     return diffs;
   } catch (error) {
     if ((error.message && error.message.match(/stack|recursion/i)) || (error.number === -2146828260)) {

--- a/src/defaultNotifier.js
+++ b/src/defaultNotifier.js
@@ -8,6 +8,52 @@ const moreInfoHooksUrl = 'http://bit.ly/wdyr3';
 
 let inHotReload = false;
 
+// Wrap opaque values to prevent console from accessing their properties
+function safeValue(value, visited = new WeakSet()) {
+  if (!wdyrStore.options?.opaqueOverride) {
+    return value;
+  }
+  
+  const opaqueOverride = wdyrStore.options.opaqueOverride;
+  
+  // Check if the value itself is opaque
+  if (opaqueOverride(value)) {
+    // Return a safe representation that won't trigger property access
+    return `[Opaque Reference ${typeof value}]`;
+  }
+  
+  // For objects and arrays, recursively check for opaque values
+  if (value && typeof value === 'object') {
+    // Check for circular reference
+    if (visited.has(value)) {
+      return '[Circular Reference]';
+    }
+    
+    // Add to visited set
+    visited.add(value);
+    
+    // Don't modify the original, and be careful with property access
+    try {
+      if (Array.isArray(value)) {
+        return value.map(item => safeValue(item, visited));
+      }
+      
+      const safeObj = {};
+      for (const key in value) {
+        if (Object.prototype.hasOwnProperty.call(value, key)) {
+          safeObj[key] = safeValue(value[key], visited);
+        }
+      }
+      return safeObj;
+    } catch {
+      // If we can't safely traverse, return a placeholder
+      return '[Complex object with potential opaque values]';
+    }
+  }
+  
+  return value;
+}
+
 function shouldLog(reason, Component) {
   if (inHotReload) {
     return false;
@@ -51,7 +97,7 @@ function logDifference({Component, displayName, hookName, prefixMessage, diffObj
       wdyrStore.options.consoleLog(
         `${diffTypesDescriptions[diffType]}. (more info at ${hookName ? moreInfoHooksUrl : moreInfoUrl})`,
       );
-      wdyrStore.options.consoleLog({[`prev ${pathString}`]: prevValue}, '!==', {[`next ${pathString}`]: nextValue});
+      wdyrStore.options.consoleLog({[`prev ${pathString}`]: safeValue(prevValue)}, '!==', {[`next ${pathString}`]: safeValue(nextValue)});
       if (diffType === diffTypes.deepEquals) {
         wdyrStore.options.consoleLog({'For detailed diff, right click the following fn, save as global, and run: ': diffFn});
       }
@@ -67,7 +113,7 @@ function logDifference({Component, displayName, hookName, prefixMessage, diffObj
         'This usually means this component called setState when no changes in its state actually occurred.',
       `More info at ${moreInfoUrl}`
     );
-    wdyrStore.options.consoleLog(`prev ${diffObjType}:`, values.prev, ' !== ', values.next, `:next ${diffObjType}`);
+    wdyrStore.options.consoleLog(`prev ${diffObjType}:`, safeValue(values.prev), ' !== ', safeValue(values.next), `:next ${diffObjType}`);
   }
 }
 

--- a/src/findObjectsDifferences.js
+++ b/src/findObjectsDifferences.js
@@ -3,13 +3,28 @@ import calculateDeepEqualDiffs from './calculateDeepEqualDiffs';
 
 const emptyObject = {};
 
-export default function findObjectsDifferences(userPrevObj, userNextObj, {shallow = true} = {}) {
+export default function findObjectsDifferences(userPrevObj, userNextObj, {shallow = true, opaqueOverride} = {}) {
   if (userPrevObj === userNextObj) {
     return false;
   }
 
+  // Check if either object should be treated as opaque
+  if (opaqueOverride) {
+    const prevIsOpaque = opaqueOverride(userPrevObj);
+    const nextIsOpaque = opaqueOverride(userNextObj);
+    if (prevIsOpaque || nextIsOpaque) {
+      // If either is opaque, they're different unless they're the same reference (which we already checked)
+      return [{
+        pathString: '',
+        diffType: 'different',
+        prevValue: userPrevObj,
+        nextValue: userNextObj,
+      }];
+    }
+  }
+
   if (!shallow) {
-    return calculateDeepEqualDiffs(userPrevObj, userNextObj);
+    return calculateDeepEqualDiffs(userPrevObj, userNextObj, '', {opaqueOverride});
   }
 
   const prevObj = userPrevObj || emptyObject;
@@ -18,7 +33,7 @@ export default function findObjectsDifferences(userPrevObj, userNextObj, {shallo
   const keysOfBothObjects = Object.keys({...prevObj, ...nextObj});
 
   return reduce(keysOfBothObjects, (result, key) => {
-    const deepEqualDiffs = calculateDeepEqualDiffs(prevObj[key], nextObj[key], key);
+    const deepEqualDiffs = calculateDeepEqualDiffs(prevObj[key], nextObj[key], key, {opaqueOverride});
     if (deepEqualDiffs) {
       result = [
         ...result,

--- a/src/getUpdateInfo.js
+++ b/src/getUpdateInfo.js
@@ -19,10 +19,43 @@ function getOwnerDifferences(prevOwner, nextOwner) {
       prevOwnerData.hooksInfo.slice(prevOwnerData.hooksInfo.length / 2) :
       prevOwnerData.hooksInfo;
 
-    const hookDifferences = prevOwnerDataHooks.map(({hookName, result}, i) => ({
-      hookName,
-      differences: findObjectsDifferences(result, nextOwnerData.hooksInfo[i].result, {shallow: false}),
-    }));
+    const prevHooks = Array.isArray(prevOwnerDataHooks) ? prevOwnerDataHooks : [];
+    const nextHooks = Array.isArray(nextOwnerData?.hooksInfo) ? nextOwnerData.hooksInfo : [];
+    
+    // Handle different array lengths safely
+    const hookDifferences = [];
+    const maxLen = Math.max(prevHooks.length, nextHooks.length);
+    
+    for (let i = 0; i < maxLen; i++) {
+      const prev = prevHooks[i];
+      const next = nextHooks[i];
+      
+      if (!prev && next) {
+        // Hook was added
+        hookDifferences.push({
+          hookName: next.hookName,
+          differences: {change: 'added'},
+        });
+      } else if (prev && !next) {
+        // Hook was removed
+        hookDifferences.push({
+          hookName: prev.hookName,
+          differences: {change: 'removed'},
+        });
+      } else if (prev && next) {
+        // Both exist, compare them
+        let differences;
+        try {
+          differences = findObjectsDifferences(prev.result, next.result, {shallow: false});
+        } catch {
+          differences = {error: 'diff_failed'};
+        }
+        hookDifferences.push({
+          hookName: prev.hookName,
+          differences,
+        });
+      }
+    }
 
     return {
       propsDifferences: findObjectsDifferences(prevOwnerData.props, nextOwnerData.props),

--- a/src/getUpdateInfo.js
+++ b/src/getUpdateInfo.js
@@ -46,7 +46,10 @@ function getOwnerDifferences(prevOwner, nextOwner) {
         // Both exist, compare them
         let differences;
         try {
-          differences = findObjectsDifferences(prev.result, next.result, {shallow: false});
+          differences = findObjectsDifferences(prev.result, next.result, {
+            shallow: false,
+            opaqueOverride: wdyrStore.options?.opaqueOverride
+          });
         } catch {
           differences = {error: 'diff_failed'};
         }
@@ -58,8 +61,12 @@ function getOwnerDifferences(prevOwner, nextOwner) {
     }
 
     return {
-      propsDifferences: findObjectsDifferences(prevOwnerData.props, nextOwnerData.props),
-      stateDifferences: findObjectsDifferences(prevOwnerData.state, nextOwnerData.state),
+      propsDifferences: findObjectsDifferences(prevOwnerData.props, nextOwnerData.props, {
+        opaqueOverride: wdyrStore.options?.opaqueOverride
+      }),
+      stateDifferences: findObjectsDifferences(prevOwnerData.state, nextOwnerData.state, {
+        opaqueOverride: wdyrStore.options?.opaqueOverride
+      }),
       hookDifferences: hookDifferences.length > 0 ? hookDifferences : false,
     };
   }
@@ -78,9 +85,16 @@ function getOwnerDifferences(prevOwner, nextOwner) {
 
 function getUpdateReason(prevOwner, prevProps, prevState, prevHookResult, nextOwner, nextProps, nextState, nextHookResult) {
   return {
-    propsDifferences: findObjectsDifferences(prevProps, nextProps),
-    stateDifferences: findObjectsDifferences(prevState, nextState),
-    hookDifferences: findObjectsDifferences(prevHookResult, nextHookResult, {shallow: false}),
+    propsDifferences: findObjectsDifferences(prevProps, nextProps, {
+      opaqueOverride: wdyrStore.options?.opaqueOverride
+    }),
+    stateDifferences: findObjectsDifferences(prevState, nextState, {
+      opaqueOverride: wdyrStore.options?.opaqueOverride
+    }),
+    hookDifferences: findObjectsDifferences(prevHookResult, nextHookResult, {
+      shallow: false,
+      opaqueOverride: wdyrStore.options?.opaqueOverride
+    }),
     ownerDifferences: getOwnerDifferences(prevOwner, nextOwner),
   };
 }

--- a/src/normalizeOptions.js
+++ b/src/normalizeOptions.js
@@ -38,6 +38,7 @@ export default function normalizeOptions(userOptions = {}) {
     textBackgroundColor: 'white',
     trackExtraHooks: [],
     trackAllPureComponents: false,
+    opaqueOverride: null,
     ...userOptions,
   };
 }

--- a/src/printDiff.js
+++ b/src/printDiff.js
@@ -1,10 +1,14 @@
 import {sortBy, groupBy} from 'lodash';
 
+import wdyrStore from './wdyrStore';
 import calculateDeepEqualDiffs from './calculateDeepEqualDiffs';
 import {diffTypesDescriptions} from './consts';
 
 export default function printDiff(value1, value2, {pathString, consoleLog}) {
-  const diffs = calculateDeepEqualDiffs(value1, value2, pathString, {detailed: true});
+  const diffs = calculateDeepEqualDiffs(value1, value2, pathString, {
+    detailed: true,
+    opaqueOverride: wdyrStore.options?.opaqueOverride
+  });
 
   const keysLength = Math.max(...diffs.map(diff => diff.pathString.length)) + 2;
 

--- a/tests/getUpdateInfo.test.js
+++ b/tests/getUpdateInfo.test.js
@@ -521,3 +521,231 @@ describe('getUpdateInfo', () => {
     });
   });
 });
+
+describe('getUpdateInfo - hook differences', () => {
+  let wdyrStore;
+
+  beforeEach(() => {
+    whyDidYouRender(React);
+    wdyrStore = require('~/wdyrStore').default;
+  });
+
+  afterEach(() => {
+    React.__REVERT_WHY_DID_YOU_RENDER__();
+    jest.restoreAllMocks();
+  });
+
+  test('Empty next hooks - prev length > 0, next []', () => {
+    const prevOwner = {};
+    const nextOwner = {};
+
+    wdyrStore.ownerDataMap.set(prevOwner, {
+      props: {},
+      state: null,
+      hooksInfo: [
+        {hookName: 'useState', result: {value: 1}},
+        {hookName: 'useEffect', result: undefined},
+        {hookName: 'useMemo', result: 42},
+      ],
+    });
+
+    wdyrStore.ownerDataMap.set(nextOwner, {
+      props: {},
+      state: null,
+      hooksInfo: [],
+    });
+
+    const updateInfo = getUpdateInfo({
+      Component: TestComponent,
+      displayName: getDisplayName(TestComponent),
+      prevOwner,
+      nextOwner,
+      prevProps: {},
+      prevState: null,
+      nextProps: {},
+      nextState: null,
+    });
+
+    expect(updateInfo.reason.ownerDifferences).toBeTruthy();
+    expect(updateInfo.reason.ownerDifferences.hookDifferences).toEqual([
+      {
+        hookName: 'useState',
+        differences: {change: 'removed'},
+      },
+      {
+        hookName: 'useEffect',
+        differences: {change: 'removed'},
+      },
+      {
+        hookName: 'useMemo',
+        differences: {change: 'removed'},
+      },
+    ]);
+  });
+
+  test('Shorter next hooks - prev length n, next length n-1', () => {
+    const prevOwner = {};
+    const nextOwner = {};
+
+    const stateResult = {value: 1};
+
+    wdyrStore.ownerDataMap.set(prevOwner, {
+      props: {},
+      state: null,
+      hooksInfo: [
+        {hookName: 'useState', result: stateResult},
+        {hookName: 'useEffect', result: undefined},
+        {hookName: 'useMemo', result: 42},
+      ],
+    });
+
+    wdyrStore.ownerDataMap.set(nextOwner, {
+      props: {},
+      state: null,
+      hooksInfo: [
+        {hookName: 'useState', result: stateResult},
+        {hookName: 'useEffect', result: undefined},
+      ],
+    });
+
+    const updateInfo = getUpdateInfo({
+      Component: TestComponent,
+      displayName: getDisplayName(TestComponent),
+      prevOwner,
+      nextOwner,
+      prevProps: {},
+      prevState: null,
+      nextProps: {},
+      nextState: null,
+    });
+
+    expect(updateInfo.reason.ownerDifferences).toBeTruthy();
+    expect(updateInfo.reason.ownerDifferences.hookDifferences).toEqual([
+      {
+        hookName: 'useState',
+        differences: false,
+      },
+      {
+        hookName: 'useEffect',
+        differences: false,
+      },
+      {
+        hookName: 'useMemo',
+        differences: {change: 'removed'},
+      },
+    ]);
+  });
+
+  test('Longer next hooks - prev n-1, next n', () => {
+    const prevOwner = {};
+    const nextOwner = {};
+
+    const stateResult = {value: 1};
+
+    wdyrStore.ownerDataMap.set(prevOwner, {
+      props: {},
+      state: null,
+      hooksInfo: [
+        {hookName: 'useState', result: stateResult},
+        {hookName: 'useEffect', result: undefined},
+      ],
+    });
+
+    wdyrStore.ownerDataMap.set(nextOwner, {
+      props: {},
+      state: null,
+      hooksInfo: [
+        {hookName: 'useState', result: stateResult},
+        {hookName: 'useEffect', result: undefined},
+        {hookName: 'useMemo', result: 42},
+      ],
+    });
+
+    const updateInfo = getUpdateInfo({
+      Component: TestComponent,
+      displayName: getDisplayName(TestComponent),
+      prevOwner,
+      nextOwner,
+      prevProps: {},
+      prevState: null,
+      nextProps: {},
+      nextState: null,
+    });
+
+    expect(updateInfo.reason.ownerDifferences).toBeTruthy();
+    expect(updateInfo.reason.ownerDifferences.hookDifferences).toEqual([
+      {
+        hookName: 'useState',
+        differences: false,
+      },
+      {
+        hookName: 'useEffect',
+        differences: false,
+      },
+      {
+        hookName: 'useMemo',
+        differences: {change: 'added'},
+      },
+    ]);
+  });
+
+  test('Diff failure safety - findObjectsDifferences throws error', () => {
+    const prevOwner = {};
+    const nextOwner = {};
+
+    wdyrStore.ownerDataMap.set(prevOwner, {
+      props: {},
+      state: null,
+      hooksInfo: [
+        {hookName: 'useState', result: {value: 1}},
+        {hookName: 'useEffect', result: {deps: [1, 2, 3]}},
+      ],
+    });
+
+    wdyrStore.ownerDataMap.set(nextOwner, {
+      props: {},
+      state: null,
+      hooksInfo: [
+        {hookName: 'useState', result: {value: 2}},
+        {hookName: 'useEffect', result: {deps: [4, 5, 6]}},
+      ],
+    });
+
+    const findObjectsDifferencesModule = require('~/findObjectsDifferences');
+    const originalFindObjectsDifferences = findObjectsDifferencesModule.default;
+    
+    let hookDiffCallCount = 0;
+    jest.spyOn(findObjectsDifferencesModule, 'default').mockImplementation((prev, next, options) => {
+      if (options && options.shallow === false && prev && next) {
+        hookDiffCallCount++;
+        if (hookDiffCallCount <= 2) {
+          throw new Error('Simulated diff error');
+        }
+      }
+      return originalFindObjectsDifferences(prev, next, options);
+    });
+
+    const updateInfo = getUpdateInfo({
+      Component: TestComponent,
+      displayName: getDisplayName(TestComponent),
+      prevOwner,
+      nextOwner,
+      prevProps: {},
+      prevState: null,
+      nextProps: {},
+      nextState: null,
+    });
+
+    expect(updateInfo.reason.ownerDifferences).toBeTruthy();
+    expect(updateInfo.reason.ownerDifferences.hookDifferences).toEqual([
+      {
+        hookName: 'useState',
+        differences: {error: 'diff_failed'},
+      },
+      {
+        hookName: 'useEffect',
+        differences: {error: 'diff_failed'},
+      },
+    ]);
+  });
+});

--- a/tests/opaqueOverride.test.js
+++ b/tests/opaqueOverride.test.js
@@ -1,0 +1,290 @@
+/* eslint-disable no-unused-vars */
+import React from 'react';
+import * as rtl from '@testing-library/react';
+
+import whyDidYouRender from '~';
+import {diffTypes} from '~/consts';
+
+describe('opaqueOverride', () => {
+  let updateInfos = [];
+
+  beforeEach(() => {
+    updateInfos = [];
+  });
+
+  afterEach(() => {
+    if (React.__REVERT_WHY_DID_YOU_RENDER__) {
+      React.__REVERT_WHY_DID_YOU_RENDER__();
+    }
+  });
+
+  test('treats objects as opaque when opaqueOverride returns true', () => {
+    // Simulate Reanimated SharedValue
+    const createSharedValue = (value) => ({
+      _isReanimatedSharedValue: true,
+      value,
+      // These should never be accessed due to opaqueOverride
+      get: () => { throw new Error('Should not access SharedValue internals'); },
+      set: () => { throw new Error('Should not access SharedValue internals'); },
+    });
+
+    whyDidYouRender(React, {
+      notifier: updateInfo => updateInfos.push(updateInfo),
+      opaqueOverride: (obj) => obj && obj._isReanimatedSharedValue === true,
+    });
+
+    const sharedValue1 = createSharedValue(1);
+    const sharedValue2 = createSharedValue(1); // Same value but different reference
+
+    const Component = ({sharedProp}) => {
+      return <div>Test</div>;
+    };
+    Component.whyDidYouRender = true;
+
+    const {rerender} = rtl.render(<Component sharedProp={sharedValue1} />);
+
+    // Rerender with different SharedValue reference
+    rerender(<Component sharedProp={sharedValue2} />);
+
+    // Should detect as different because they're different references
+    expect(updateInfos).toHaveLength(1);
+    expect(updateInfos[0].reason.propsDifferences).toEqual([{
+      pathString: 'sharedProp',
+      diffType: diffTypes.different,
+      prevValue: sharedValue1,
+      nextValue: sharedValue2,
+    }]);
+  });
+
+  test('detects no change when same opaque reference is passed', () => {
+    // Track if internal data is accessed
+    let dataAccessed = false;
+    const createOpaqueObject = (id) => ({
+      _opaque: true,
+      id,
+      // Should never be accessed when using opaqueOverride
+      get data() {
+        dataAccessed = true;
+        return 'internal-data';
+      },
+    });
+
+    whyDidYouRender(React, {
+      notifier: updateInfo => updateInfos.push(updateInfo),
+      opaqueOverride: (obj) => obj && obj._opaque === true,
+    });
+
+    const opaqueObj = createOpaqueObject('test');
+
+    const Component = ({opaqueProp, regularProp}) => {
+      return <div>Test</div>;
+    };
+    Component.whyDidYouRender = true;
+
+    const {rerender} = rtl.render(
+      <Component opaqueProp={opaqueObj} regularProp={1} />
+    );
+
+    // Rerender with same opaque reference but different regular prop
+    rerender(<Component opaqueProp={opaqueObj} regularProp={2} />);
+
+    // Verify internal data was never accessed
+    expect(dataAccessed).toBe(false);
+
+    // Should only detect regularProp change
+    expect(updateInfos).toHaveLength(1);
+
+    // Filter out "same" differences for the assertion
+    const actualDifferences = updateInfos[0].reason.propsDifferences.filter(
+      diff => diff.diffType !== diffTypes.same
+    );
+
+    expect(actualDifferences).toEqual([{
+      pathString: 'regularProp',
+      diffType: diffTypes.different,
+      prevValue: 1,
+      nextValue: 2,
+    }]);
+  });
+
+  test('handles transition from undefined to opaque object', () => {
+    const createSharedValue = (value) => ({
+      _isReanimatedSharedValue: true,
+      value,
+    });
+
+    whyDidYouRender(React, {
+      notifier: updateInfo => updateInfos.push(updateInfo),
+      opaqueOverride: (obj) => obj && obj._isReanimatedSharedValue === true,
+    });
+
+    const Component = ({sharedProp}) => {
+      return <div>Test</div>;
+    };
+    Component.whyDidYouRender = true;
+
+    const {rerender} = rtl.render(<Component sharedProp={undefined} />);
+
+    const sharedValue = createSharedValue(1);
+    rerender(<Component sharedProp={sharedValue} />);
+
+    // Should detect change from undefined to SharedValue
+    expect(updateInfos).toHaveLength(1);
+    expect(updateInfos[0].reason.propsDifferences).toEqual([{
+      pathString: 'sharedProp',
+      diffType: diffTypes.different,
+      prevValue: undefined,
+      nextValue: sharedValue,
+    }]);
+  });
+
+  test('handles transition from opaque object to regular value', () => {
+    const createSharedValue = (value) => ({
+      _isReanimatedSharedValue: true,
+      value,
+    });
+
+    whyDidYouRender(React, {
+      notifier: updateInfo => updateInfos.push(updateInfo),
+      opaqueOverride: (obj) => obj && obj._isReanimatedSharedValue === true,
+    });
+
+    const Component = ({sharedProp}) => {
+      return <div>Test</div>;
+    };
+    Component.whyDidYouRender = true;
+
+    const sharedValue = createSharedValue(1);
+    const {rerender} = rtl.render(<Component sharedProp={sharedValue} />);
+
+    rerender(<Component sharedProp="regular string" />);
+
+    // Should detect change from SharedValue to string
+    expect(updateInfos).toHaveLength(1);
+    expect(updateInfos[0].reason.propsDifferences).toEqual([{
+      pathString: 'sharedProp',
+      diffType: diffTypes.different,
+      prevValue: sharedValue,
+      nextValue: 'regular string',
+    }]);
+  });
+
+  test('opaqueOverride works with nested properties', () => {
+    const createSharedValue = (value) => ({
+      _isReanimatedSharedValue: true,
+      value,
+    });
+
+    whyDidYouRender(React, {
+      notifier: updateInfo => updateInfos.push(updateInfo),
+      opaqueOverride: (obj) => obj && obj._isReanimatedSharedValue === true,
+    });
+
+    const sharedValue1 = createSharedValue(1);
+    const sharedValue2 = createSharedValue(2);
+
+    const Component = ({config}) => {
+      return <div>Test</div>;
+    };
+    Component.whyDidYouRender = true;
+
+    const {rerender} = rtl.render(
+      <Component config={{animation: sharedValue1, speed: 100}} />
+    );
+
+    // Change nested SharedValue
+    rerender(<Component config={{animation: sharedValue2, speed: 100}} />);
+
+    // Should detect the nested SharedValue change
+    expect(updateInfos).toHaveLength(1);
+    const diffs = updateInfos[0].reason.propsDifferences;
+
+    // The config object itself changed
+    expect(diffs.find(d => d.pathString === 'config')).toBeTruthy();
+
+    // The nested animation property changed (different SharedValue references)
+    const animationDiff = diffs.find(d => d.pathString === 'config.animation');
+    expect(animationDiff).toEqual({
+      pathString: 'config.animation',
+      diffType: diffTypes.different,
+      prevValue: sharedValue1,
+      nextValue: sharedValue2,
+    });
+  });
+
+  test('opaque values are not accessed when logged to console', () => {
+    let accessCount = 0;
+    const createTrackedSharedValue = (value) => ({
+      _isReanimatedSharedValue: true,
+      get value() {
+        accessCount++;
+        return value;
+      },
+      // Other properties that should never be accessed
+      get _value() {
+        throw new Error('Should not access internal _value');
+      },
+    });
+
+    const consoleLogs = [];
+    whyDidYouRender(React, {
+      consoleLog: (...args) => consoleLogs.push(args),
+      consoleGroup: () => {},
+      consoleGroupEnd: () => {},
+      logOnDifferentValues: true,
+      opaqueOverride: (obj) => obj && obj._isReanimatedSharedValue === true,
+    });
+
+    const sharedValue1 = createTrackedSharedValue(1);
+    const sharedValue2 = createTrackedSharedValue(2);
+
+    const Component = ({sharedProp}) => {
+      return <div>Test</div>;
+    };
+    Component.whyDidYouRender = true;
+
+    const {rerender} = rtl.render(<Component sharedProp={sharedValue1} />);
+    rerender(<Component sharedProp={sharedValue2} />);
+
+    // Check that logs contain safe representations
+    const logStrings = JSON.stringify(consoleLogs);
+    expect(logStrings).toContain('[Opaque Reference object]');
+
+    // Verify that the value getter was never called during logging
+    expect(accessCount).toBe(0);
+  });
+
+  test('without opaqueOverride, objects are compared deeply', () => {
+    // Without opaqueOverride, this would normally try to access properties
+    const obj1 = {
+      _isReanimatedSharedValue: true,
+      value: 1,
+    };
+    const obj2 = {
+      _isReanimatedSharedValue: true,
+      value: 1,
+    };
+
+    whyDidYouRender(React, {
+      notifier: updateInfo => updateInfos.push(updateInfo),
+      // No opaqueOverride specified
+    });
+
+    const Component = ({prop: _prop}) => {
+      return <div>Test</div>;
+    };
+    Component.whyDidYouRender = true;
+
+    const {rerender} = rtl.render(<Component prop={obj1} />);
+    rerender(<Component prop={obj2} />);
+
+    // Without opaqueOverride, it compares deeply and finds them equal
+    expect(updateInfos).toHaveLength(1);
+    expect(updateInfos[0].reason.propsDifferences).toEqual([{
+      pathString: 'prop',
+      diffType: diffTypes.deepEquals,
+      prevValue: obj1,
+      nextValue: obj2,
+    }]);
+  });
+});

--- a/types.d.ts
+++ b/types.d.ts
@@ -46,6 +46,7 @@ export interface WhyDidYouRenderOptions {
   textBackgroundColor?: string;
   notifier?: Notifier;
   customName?: string;
+  opaqueOverride?: (obj: any) => boolean;
 }
 
 export type WhyDidYouRenderComponentMember = WhyDidYouRenderOptions | boolean


### PR DESCRIPTION
When using react-native-reanimated, this library will spread, and traverse SharedValue and DerivedValue objects, causing a warning due to render-time access to reanimated value.

This addition let's the user add `opaqueOverride`, so that they can tell the comparator and logger not to bother deep checking certain stuff.

Currently I'm getting a console grouping warning in the app while testing, going to have to take a look at that, hence the draft.

Also, this might *slightly* but not necessarily conflict with having custom comparator override.